### PR TITLE
Allow translated strings in the help property

### DIFF
--- a/kirby3-blueprints.schema.json
+++ b/kirby3-blueprints.schema.json
@@ -961,7 +961,7 @@
         "$ref": "#/$defs/nonEmptyString"
       },
       "@help": {
-        "$ref": "#/$defs/nonEmptyString",
+        "$ref": "#/$defs/stringOrTranslated",
         "description": "Optional help text below the field"
       },
       "@image": {

--- a/tests/fixtures/blueprints/page.yml
+++ b/tests/fixtures/blueprints/page.yml
@@ -29,4 +29,8 @@ sections:
           en: Localized Text
           de: Übersetzter Text
           fr: Texte localisé
+        help:
+          en: Localized Text
+          de: Übersetzter Text
+          fr: Texte localisé
         type: text


### PR DESCRIPTION
We use a lot of translated help texts in our projects. This fixes a lot of messages ;)
I took the liberty of taking [gnuj](https://github.com/gnuj) test array.
