### PR TITLE
Allow email mark in writer field

### DIFF
--- a/kirby3-blueprints.schema.json
+++ b/kirby3-blueprints.schema.json
@@ -151,7 +151,8 @@
         "underline",
         "strike",
         "code",
-        "link"
+        "link",
+        "email"
       ]
     },
     "nodes": {

--- a/tests/fixtures/fields/writer.yml
+++ b/tests/fixtures/fields/writer.yml
@@ -4,5 +4,6 @@ marks:
   - bold
   - italic
   - strike
+  - email
 nodes:
   - paragraph


### PR DESCRIPTION
A small fix to allow the email mark in a writer field.