### PR TITLE
Various improvements for Kirby 5

### DIFF
--- a/kirby5-blueprints.schema.json
+++ b/kirby5-blueprints.schema.json
@@ -387,7 +387,7 @@
               "$ref": "#/$defs/field-properties/@label"
             },
             "text": {
-              "$ref": "#/$defs/nonEmptyString"
+              "$ref": "#/$defs/stringOrTranslated"
             }
           }
         }

--- a/kirby5-blueprints.schema.json
+++ b/kirby5-blueprints.schema.json
@@ -1163,7 +1163,7 @@
         "description": "Image options to control the source and look of file previews"
       },
       "@icon": {
-        "oneOf": [
+        "anyOf": [
           {
             "$ref": "#/$defs/nonEmptyString"
           },

--- a/kirby5-blueprints.schema.json
+++ b/kirby5-blueprints.schema.json
@@ -432,6 +432,9 @@
         },
         "theme": {
           "$ref": "#/$defs/field-properties/@theme"
+        },
+        "icon": {
+          "$ref": "#/$defs/field-properties/@icon"
         }
       }
     },

--- a/kirby5-blueprints.schema.json
+++ b/kirby5-blueprints.schema.json
@@ -1577,7 +1577,10 @@
           "none",
           "positive",
           "info",
-          "negative"
+          "negative",
+          "warning",
+          "notice",
+          "love"
         ]
       },
       "@toolbar": {

--- a/kirby5-blueprints.schema.json
+++ b/kirby5-blueprints.schema.json
@@ -860,6 +860,9 @@
               "site"
             ]
           },
+          "icon": {
+            "$ref": "#/$defs/blueprint-properties/@icon"
+          },
           "title": {
             "$ref": "#/$defs/blueprint-properties/@title"
           },

--- a/tests/fixtures/blueprints/file.yml
+++ b/tests/fixtures/blueprints/file.yml
@@ -16,7 +16,7 @@ accept:
 
 image:
   back: blue-200
-  icon: 📝
+  icon: page
 
 options:
   delete:

--- a/tests/fixtures/blueprints/site.yml
+++ b/tests/fixtures/blueprints/site.yml
@@ -1,5 +1,7 @@
 blueprint: site
 
+icon: home
+
 title:
   en: Site
   de: Webseite

--- a/tests/fixtures/fields/stats.yml
+++ b/tests/fixtures/fields/stats.yml
@@ -7,11 +7,11 @@ reports:
     value: €29,682
     info: +112.5%
     link: https://getkirby.com/shop
-    theme: positive
+    theme: love
   - label: Orders
     value: 265
     info: +82.8%
-    theme: positive
+    theme: warning
   - label: Avg. Transaction
     value: €112.01
     info: +16.3%

--- a/tests/fixtures/misc/page001.yml
+++ b/tests/fixtures/misc/page001.yml
@@ -10,6 +10,15 @@ create:
   redirect: false
   status: draft
 
+status:
+  draft:
+    label:
+      en: English label
+      de: Deutscher Titel
+    text:
+      en: English subtext
+      de: Deutscher Untertitel
+
 options:
   preview: "{{ site.url }}?preview={{ page.slug }}"
 

--- a/tests/fixtures/sections/stats.yml
+++ b/tests/fixtures/sections/stats.yml
@@ -8,10 +8,12 @@ reports:
     info: +112.5%
     link: https://getkirby.com/shop
     theme: love
+    icon: custom
   - label: Orders
     value: 265
     info: +82.8%
     theme: positive
+    icon: car
   - label: Avg. Transaction
     value: €112.01
     info: +16.3%

--- a/tests/fixtures/sections/stats.yml
+++ b/tests/fixtures/sections/stats.yml
@@ -7,7 +7,7 @@ reports:
     value: €29,682
     info: +112.5%
     link: https://getkirby.com/shop
-    theme: positive
+    theme: love
   - label: Orders
     value: 265
     info: +82.8%

--- a/tests/misc.test.js
+++ b/tests/misc.test.js
@@ -1,0 +1,17 @@
+const validate = require('./validate')
+
+test('page001', () => {
+    expect(validate('./tests/fixtures/misc/page001.yml')).toBeTruthy();
+});
+
+test('page002', () => {
+    expect(validate('./tests/fixtures/misc/page002.yml')).toBeTruthy();
+});
+
+test('page003', () => {
+    expect(validate('./tests/fixtures/misc/page003.yml')).toBeTruthy();
+});
+
+test('page004', () => {
+    expect(validate('./tests/fixtures/misc/page004.yml')).toBeTruthy();
+});


### PR DESCRIPTION
- adds `icon` to `stats/report`
- adds `icon` to `blueprints/site`
- adds additional (new?) themes: `love`, `warning`, `notice`
- fixes field icon issue: any of the enums were throwing on the `oneOf`
- added `fixtures/misc/*.js` to tests
- set page draft text to `stringOrTranslatable`

Also with tests for most of these